### PR TITLE
Ĝisdatigis Localizable.strings

### DIFF
--- a/PoshReVo/Helpajhoj/Base.lproj/Localizable.strings
+++ b/PoshReVo/Helpajhoj/Base.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-/* 
+/*
   Localizable.strings
   PoshReVo
 
@@ -13,7 +13,7 @@
 "flanko historio etikedo"                       = "Historio";
 "flanko konservitaj etikedo"                    = "Konservitaj";
 "flanko agordoj etikedo"                        = "Agordoj";
-"flanko informo etikedo"                        = "Informo";
+"flanko informo etikedo"                        = "Informoj";
 
 // Serchi
 
@@ -25,7 +25,7 @@
 
 "esplori titolo"                                = "Esplori";
 "esplori fakoj titolo"                          = "Fakoj";
-"esplori iu ajn titolo"                         = "Iu Ajn Artikolo";
+"esplori iu ajn titolo"                         = "Iu ajn artikolo";
 
 // Historio
 
@@ -41,48 +41,48 @@
 "agordoj datumoj etikedo"                       = "Datumoj";
 "agordoj lingvoj etikedo"                       = "Lingvoj";
 "agordoj aspekto etikedo"                       = "Aspekto";
-"agordoj nuligi historion etikedo"              = "Nuligi Historion";
-"agordoj nuligi konservitajn etikedo"           = "Nuligi Konservitajn";
-"agordoj elekti serch-lingvon etikedo"          = "Elekti Serĉ-lingvojn";
-"agordoj elekti traduk-lingvojn etikedo"        = "Elekti Traduk-lingvojn";
-"agordoj elekti stilon etikedo"                 = "Elekti Stilon";
+"agordoj nuligi historion etikedo"              = "Forigi la historion";
+"agordoj nuligi konservitajn etikedo"           = "Forigi la konservitajn";
+"agordoj elekti serch-lingvon etikedo"          = "Elekti serĉ-lingvojn";
+"agordoj elekti traduk-lingvojn etikedo"        = "Elekti traduk-lingvojn";
+"agordoj elekti stilon etikedo"                 = "Elekti stilon";
 "agordoj traduk-lingvoj subetikedo"             = "%@ lingvoj";
-"agordoj nuligi historion averto"               = "Ĉu nuligu historion?";
-"agordoj nuligi konservitajn averto"            = "Ĉu nuligu konservitajn artikolojn?";
+"agordoj nuligi historion averto"               = "Ĉu forigi la historion?";
+"agordoj nuligi konservitajn averto"            = "Ĉu forigi la konservitajn artikolojn?";
 
 // Pri
-"informo titolo"                                = "Informo";
+"informo titolo"                                = "Informoj";
 
 "informo revo titolo"                           = "Pri ReVo";
-"informo revo teksto"                           = "<b>Reta Vortaro</b>\nReta Vortaro estas vortaro de la esperanta lingvo, legebla senpage sur la reto ĉe <a href=\"http://www.reta-vortaro.de\">www.reta-vortaro.de</a>. Ĉi apo kolektas kaj prezentas la difinojn kaj tradukojn kiujn enhavas ĝi, samkiel ili aperas tie.\n\n<b>Redaktado</b>\nReta Vortaro estas redaktata de rondo de volontuloj. Se vi trovas eraron aŭ mankon, aŭ simple deziras kontribui al libera kaj aktuala vortaro sur la reto, <a href=\"http://www.reta-vortaro.de/revo/dok/redinfo.html\">fariĝu redaktanto</a>.";
+"informo revo teksto"                           = "<b>Reta Vortaro</b>\nReta Vortaro estas vortaro de Esperanto, legebla senpage sur la reto ĉe <a href=\"http://www.reta-vortaro.de\">www.reta-vortaro.de</a>. Ĉi tiu apo kolektas kaj prezentas la difinojn kaj tradukojn kiujn enhavas ĝi, samkiel ili aperas tie.\n\n<b>Redaktado</b>\nReta Vortaro estas redaktata de rondo de volontuloj. Se vi trovas eraron aŭ mankon, aŭ simple deziras kontribui al libera kaj aktuala vortaro sur la reto, <a href=\"http://www.reta-vortaro.de/revo/dok/redinfo.html\">fariĝu redaktanto</a>.";
 
-"informo vortaraj-mallongigoj titolo"           = "Vortaraj Mallongigoj";
-"informo fakaj-mallongigoj titolo"              = "Fakaj Mallongigoj";
+"informo vortaraj-mallongigoj titolo"           = "Vortaraj mallongigoj";
+"informo fakaj-mallongigoj titolo"              = "Fakaj mallongigoj";
 
 "informo poshrevo titolo"                       = "Pri PoŝReVo";
-"informo poshrevo teksto"                       = "<b>Poŝa Reta Vortaro</b>\nPoŝa Reta Vortaro estas programita de Robin Hill. Plena informo troviĝas ĉe <a href=\"http://www.inthescales.com/projects/poshrevo_eo\">ĉi tiu retpaĝo</a>.\n\nSe vi bezonas helpon, renkontis eraron, aŭ havas ajnaspecan komenton vi povas kontakti per retpoŝtmesaĝo al <a href=\"mailto:contact@inthescales.com\">tiu ĉi adreso</a>.\n\n<b>Kodaro</b>\nLa font-kodo de ĉi tiu programo estas libere havebla kaj oni rajtas legi, kopii, ŝanĝi, redisdoni, kaj vendi ĝin ajnamaniere. Tiu kodo disponeblas <a href=\"https://www.github.com/inthescales/PoshReVo\">ĉi tie</a>, kaj estas eldonita sub la <a href=\"http://www.gnu.org/licenses/old-licenses/gpl-2.0.html\">GPLv2 Permesilo</a>.\n\nLa enapaj bildetoj venas de <a href=\"http://www.icons8.com\">icons8</a>.\n\n\n<i>Poŝa Reta Vortaro, PoŝReVo © 2016-2019, Robin Hill\n\n%@</i>";
+"informo poshrevo teksto"                       = "<b>Poŝa Reta Vortaro</b>\nPoŝa Reta Vortaro estas programita de Robin Hill. Plenaj informoj troviĝas ĉe <a href=\"http://www.inthescales.com/projects/poshrevo_eo\">ĉi tiu retpaĝo</a>.\n\nSe vi bezonas helpon, renkontis eraron, aŭ havas ajnaspecan komenton vi povas kontakti per retpoŝtmesaĝo al <a href=\"mailto:contact@inthescales.com\">tiu ĉi adreso</a>.\n\n<b>Kodaro</b>\nLa font-kodo de ĉi tiu programo estas libere havebla kaj oni rajtas legi, kopii, ŝanĝi, redisdoni, kaj vendi ĝin ajnamaniere. Tiu kodo disponeblas <a href=\"https://www.github.com/inthescales/PoshReVo\">ĉi tie</a>, kaj estas eldonita sub la permesilo <a href=\"http://www.gnu.org/licenses/old-licenses/gpl-2.0.html\">GPLv2</a>.\n\nLa enapaj bildetoj venas de <a href=\"http://www.icons8.com\">icons8</a>.\n\n\n<i>Poŝa Reta Vortaro, PoŝReVo © 2016-2020, Robin Hill\n\n%@</i>";
 
-"informo versio"                                = "Versio numero %@";
+"informo versio"                                = "Versio-numero %@";
 
 // Artikolo pagho
 
 "artikolo tradukoj etikedo"                     = "Tradukoj";
 "artikolo chelo agoj titolo"                    = "Difinaj agoj:";
-"artikolo chelo ago kopii"                      = "Kopii tekston";
+"artikolo chelo ago kopii"                      = "Kopii la tekston";
 
 // Serch lingvo elektilo
 
 "lingvo-elektilo sercha titolo"                 = "Elekti serĉ-lingvon";
 "lingvo-elektilo traduka titolo"                = "Elekti traduk-lingvon";
-"lingvo-elektilo lastaj etikedo"                = "Lastaj Lingvoj";
-"lingvo-elektilo serchataj etikedo"             = "Lastaj Serĉ-Lingvoj ";
-"lingvo-elektilo chiuj etikedo"                 = "Ĉiuj Lingvoj";
+"lingvo-elektilo lastaj etikedo"                = "Lastaj lingvoj";
+"lingvo-elektilo serchataj etikedo"             = "Lastaj serĉ-lingvoj ";
+"lingvo-elektilo chiuj etikedo"                 = "Ĉiuj lingvoj";
 
 // Traduk lingvo elektilo
 
 "traduk-elektilo titolo"                        = "Elekti traduk-lingvojn";
 "traduk-elektilo aldoni-butono titolo"          = "Aldoni lingvon";
-"traduk-elektilo butono titolo"                 = "Montri Pliajn Tradukojn";
+"traduk-elektilo butono titolo"                 = "Montri pliajn tradukojn";
 "traduk-elektilo redakti"                       = "Redakti";
 "traduk-elektilo fini"                          = "Fini";
 
@@ -97,12 +97,12 @@
 
 // Licenco
 
-"licenco titolo"                                = "Licenco";
-"licenco teksto"                                = "NENIU ENPROGRAMA LICENC-TEKSTO NUNTEMPE";
+"licenco titolo"                                = "Permesilo";
+"licenco teksto"                                = "NENIU ENPROGRAMA PERMESIL-TEKSTO NUNTEMPE";
 
 // Gheneralaj tekstetoj
 
-"Okej"                                          = "Okej";
+"Okej"                                          = "Bone";
 "Jes"                                           = "Jes";
 "Ne"                                            = "Ne";
 "Nenio"                                         = "Nenio";


### PR DESCRIPTION
Mi faris kelkajn etajn lingvajn ŝanĝojn al la dosiero `Localizable.strings`.

En Esperanto ne vere ekzistas la kutimo majuskligi la unuan literon de ĉiu vorto, kiam temas pri aplikaĵoj.

Mi ankaŭ pensas, ke oni ne povas "nuligi" historion aŭ liston de konservitaj vortoj. Mi pensas, ke "forigi" pli taŭgas.